### PR TITLE
ntp: do not configure on SUSE

### DIFF
--- a/roles/testnode/tasks/ntp.yml
+++ b/roles/testnode/tasks/ntp.yml
@@ -24,9 +24,11 @@
     mode: 0644
   notify:
     - restart ntp
+  when: ansible_pkg_mgr != "zypper"
 
 - name: Make sure ntpd is running.
   service:
     name: "{{ntp_service_name}}"
     enabled: yes
     state: started
+  when: ansible_pkg_mgr != "zypper"

--- a/roles/testnode/tasks/resolvconf.yml
+++ b/roles/testnode/tasks/resolvconf.yml
@@ -54,9 +54,11 @@
     dest: /etc/resolv.conf
     regexp: "^search .*"
     line: "search {{ lab_domain }}"
+  when: lab_domain != ""
 
 - name: Ensure domain is set in /etc/resolv.conf
   lineinfile:
     dest: /etc/resolv.conf
     regexp: "^domain .*"
     line: "domain {{ lab_domain }}"
+  when: lab_domain != ""


### PR DESCRIPTION
We configure and start ntpd.service in the user-data

Signed-off-by: Nathan Cutler <ncutler@suse.com>
(cherry picked from commit b37c4a5b2ff66959531bcdbf8304a2a9b3e62d8a)